### PR TITLE
Disable allowed_start_tolerance

### DIFF
--- a/ur3_moveit_config/launch/move_group.launch
+++ b/ur3_moveit_config/launch/move_group.launch
@@ -67,6 +67,7 @@
     <param name="planning_scene_monitor/publish_geometry_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_state_updates" value="$(arg publish_monitored_planning_scene)" />
     <param name="planning_scene_monitor/publish_transforms_updates" value="$(arg publish_monitored_planning_scene)" />
+    <param name="trajectory_execution/allowed_start_tolerance" value="0.0"/> <!-- default 0.01, disable 0.0 -->
   </node>
 
 </launch>


### PR DESCRIPTION
The default value of allowed_start_tolerance could be too much small for UR3. Disable it for now.